### PR TITLE
simpler/faster method to get variant matrix data from numpy

### DIFF
--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -53,17 +53,8 @@ PYBIND11_MODULE(variant_matrix, m)
                              "len(pos) must equal data.shape[0]"));
                      }
                  auto data_ptr = data.unchecked<2>();
-                 std::vector<std::int8_t> d;
-                 d.reserve(data.size());
-                 for (decltype(data_ptr.shape(0)) i = 0; i < data_ptr.shape(0);
-                      ++i)
-                     {
-                         for (decltype(data_ptr.shape(1)) j = 0;
-                              j < data_ptr.shape(1); ++j)
-                             {
-                                 d.push_back(*data_ptr.data(i, j));
-                             }
-                     }
+                 std::vector<std::int8_t> d(data_ptr.data(0, 0),
+                                            data_ptr.data(0, 0) + data.size());
                  auto pos_ptr = pos.unchecked<1>();
                  std::vector<double> p(pos_ptr.data(0),
                                        pos_ptr.data(0) + pos.size());
@@ -277,7 +268,7 @@ PYBIND11_MODULE(variant_matrix, m)
               return Sequence::process_variable_sites(
                   m, refstates.cast<std::vector<std::int8_t>>());
           },
-          py::arg("m"), py::arg("refstates")=nullptr,
+          py::arg("m"), py::arg("refstates") = nullptr,
           R"delim(
           Obtain state counts for all sites
 


### PR DESCRIPTION
Implements a loop-free way to get data from numpy into a `Sequence::VariantMatrix`.