### PR TITLE
Capsule experiment

### DIFF
--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -20,24 +20,11 @@ class NumpyGenotypeCapsule : public Sequence::GenotypeCapsule
     py::array_t<std::int8_t> buffer;
     std::size_t nsites_, nsam_;
 
-    std::size_t
-    fill_nsites()
-    {
-        auto r = buffer.unchecked<2>();
-        return r.shape(0);
-    }
-    std::size_t
-    fill_nsam()
-    {
-        auto r = buffer.unchecked<2>();
-        return r.shape(1);
-    }
-
   public:
     explicit NumpyGenotypeCapsule(
         py::array_t<std::int8_t, py::array::c_style | py::array::forcecast>
             input)
-        : buffer(input), nsites_(fill_nsites()), nsam_(fill_nsam())
+        : buffer(input), nsites_(buffer.shape(0)), nsam_(buffer.shape(1))
     {
         //buffer.attr("flags").attr("writeable") = false;
     }

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -303,20 +303,23 @@ init_VariantMatrix(py::module &m)
                const double end, const std::size_t i, const std::size_t j) {
                 return Sequence::make_slice(m, beg, end, i, j);
             },
-            py::arg("beg"), py::arg("end"), py::arg("i"), py::arg("j"));
-    //.def(py::pickle(
-    //    [](const Sequence::VariantMatrix &m) {
-    //        return py::make_tuple(m.data, m.positions);
-    //    },
-    //    [](py::tuple t) {
-    //        if (t.size() != 2)
-    //            {
-    //                throw std::runtime_error("invalid object state");
-    //            }
-    //        auto d = t[0].cast<std::vector<std::int8_t>>();
-    //        auto p = t[1].cast<std::vector<double>>();
-    //        return Sequence::VariantMatrix(std::move(d), std::move(p));
-    //    }));
+            py::arg("beg"), py::arg("end"), py::arg("i"), py::arg("j"))
+        .def(py::pickle(
+            [](const Sequence::VariantMatrix &m) {
+                std::vector<std::int8_t> temp(
+                    m.data(), m.data() + m.nsites() * m.nsam());
+                std::vector<double> ptemp(m.pbegin(), m.pend());
+                return py::make_tuple(std::move(temp), std::move(ptemp));
+            },
+            [](py::tuple t) {
+                if (t.size() != 2)
+                    {
+                        throw std::runtime_error("invalid object state");
+                    }
+                auto d = t[0].cast<std::vector<std::int8_t>>();
+                auto p = t[1].cast<std::vector<double>>();
+                return Sequence::VariantMatrix(std::move(d), std::move(p));
+            }));
 
     py::class_<Sequence::ConstColView>(m, "ConstColView",
                                        R"delim(

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -133,6 +133,36 @@ class NumpyGenotypeCapsule : public Sequence::GenotypeCapsule
         return buffer.size();
     }
 
+    std::size_t
+    row_offset() const
+    {
+        return 0;
+    }
+
+    std::size_t
+    col_offset() const
+    {
+        return 0;
+    }
+
+    std::size_t
+    stride() const
+    {
+        return nsam();
+    }
+
+    std::int8_t &
+    operator()(std::size_t site, std::size_t sample)  final
+    {
+        return buffer.mutable_data()[nsam()*site + sample];
+    }
+
+    const std::int8_t &
+    operator()(std::size_t site, std::size_t sample) const final
+    {
+        return buffer.data()[nsam()*site + sample];
+    }
+
     bool
     resizable() const final
     {

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -234,6 +234,21 @@ class NumpyPositionCapsule : public Sequence::PositionCapsule
     }
 };
 
+
+class MockVM
+{
+  private:
+    std::unique_ptr<Sequence::GenotypeCapsule> g;
+    std::unique_ptr<Sequence::PositionCapsule> p;
+
+  public:
+    MockVM(std::unique_ptr<Sequence::GenotypeCapsule> g_,
+           std::unique_ptr<Sequence::PositionCapsule> p_)
+        : g(std::move(g_)), p(std::move(p_))
+    {
+    }
+};
+
 void
 init_VariantMatrix(py::module &m)
 {
@@ -778,4 +793,17 @@ init_VariantMatrix(py::module &m)
         py::object o = py::cast(std::move(vm));
         return o;
     });
+
+    py::class_<MockVM>(m, "MockVM")
+        .def(py::init([](py::array_t<std::int8_t,
+                                     py::array::c_style | py::array::forcecast>
+                             data,
+                         py::array_t<double> pos,
+                         std::int8_t max_allele_value) {
+            std::unique_ptr<Sequence::GenotypeCapsule> dp(
+                new NumpyGenotypeCapsule(data));
+            std::unique_ptr<Sequence::PositionCapsule> pp(
+                new NumpyPositionCapsule(pos));
+            return MockVM(std::move(dp), std::move(pp));
+        }));
 }

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -39,7 +39,7 @@ class NumpyGenotypeCapsule : public Sequence::GenotypeCapsule
             input)
         : buffer(input), nsites_(fill_nsites()), nsam_(fill_nsam())
     {
-        buffer.attr("flags").attr("writeable") = false;
+        //buffer.attr("flags").attr("writeable") = false;
     }
 
     std::size_t &
@@ -160,7 +160,7 @@ class NumpyPositionCapsule : public Sequence::PositionCapsule
                 throw std::invalid_argument(
                     "positions must be a one-dimensional array");
             }
-        buffer.attr("flags").attr("writeable") = false;
+        //buffer.attr("flags").attr("writeable") = false;
     }
 
     double &operator[](std::size_t i) { return buffer.mutable_data()[i]; }

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -723,8 +723,16 @@ init_VariantMatrix(py::module &m)
 
     m.def(
         "filter_haplotypes",
-        [](Sequence::VariantMatrix &m, const std::function<bool(const Sequence::ConstColView &)> &f) {
-            return Sequence::filter_haplotypes(m, f);
+        [](Sequence::VariantMatrix &m, py::function f) {
+            if (m.resizable())
+                {
+                    auto cpp_func = f.cast<
+                        std::function<bool(const Sequence::ColView &)>>();
+                    return Sequence::filter_haplotypes(m, cpp_func);
+                }
+            auto cpp_func = f.cast<
+                std::function<bool(const Sequence::ConstColView &)>>();
+            return Sequence::filter_haplotypes(m, cpp_func);
         },
         R"delim(
             Remove site data from a VariantMatrix
@@ -738,17 +746,31 @@ init_VariantMatrix(py::module &m)
 
             .. note::
 
-                Currently, the implementation works via a copy 
-                of the data. If the the VariantMatrix was initially
+                If the the VariantMatrix was initially
                 created from a numpy array, its internal state
-                is changed to be based on C++ vectors
+                is changed to be based on C++ vectors, meaning
+                that a copy happened internally.
             )delim",
         py::arg("m"), py::arg("f"));
 
     m.def(
         "filter_sites",
-        [](Sequence::VariantMatrix &m, const std::function<bool(const Sequence::ConstRowView &)> &f) {
-            return Sequence::filter_sites(m, f);
+        //[](Sequence::VariantMatrix &m,
+        //   const std::function<bool(const Sequence::ConstRowView &)> &f) {
+        //    return Sequence::filter_sites(m, f);
+        //},
+        [](Sequence::VariantMatrix &m, py::function f) {
+            if (m.resizable())
+                {
+                    auto cpp_func = f.cast<
+                        std::function<bool(const Sequence::RowView &)>>();
+
+                    return Sequence::filter_sites(m, cpp_func);
+                }
+            auto cpp_func = f.cast<
+                std::function<bool(const Sequence::ConstRowView &)>>();
+
+            return Sequence::filter_sites(m, cpp_func);
         },
         R"delim(
             Remove sample data from a VariantMatrix
@@ -762,10 +784,10 @@ init_VariantMatrix(py::module &m)
 
             .. note::
 
-                Currently, the implementation works via a copy 
-                of the data. If the the VariantMatrix was initially
+                If the the VariantMatrix was initially
                 created from a numpy array, its internal state
-                is changed to be based on C++ vectors
+                is changed to be based on C++ vectors, meaning
+                that a copy happened internally.
             )delim",
         py::arg("m"), py::arg("f"));
 

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -338,12 +338,14 @@ init_VariantMatrix(py::module &m)
             py::init([](py::array_t<std::int8_t,
                                     py::array::c_style | py::array::forcecast>
                             data,
-                        py::array_t<double> pos) {
+                        py::array_t<double> pos,
+                        std::int8_t max_allele_value) {
                 std::unique_ptr<Sequence::GenotypeCapsule> dp(
                     new NumpyGenotypeCapsule(data));
                 std::unique_ptr<Sequence::PositionCapsule> pp(
                     new NumpyPositionCapsule(pos));
-                return Sequence::VariantMatrix(std::move(dp), std::move(pp));
+                return Sequence::VariantMatrix(std::move(dp), std::move(pp),
+                                               max_allele_value);
 
                 //if (data.ndim() != 2)
                 //    {
@@ -382,7 +384,7 @@ init_VariantMatrix(py::module &m)
             >>> p = np.array([0.1,0.2])
             >>> m = vm.VariantMatrix(d,p)
             )delim",
-            py::arg("data"), py::arg("pos"))
+            py::arg("data"), py::arg("pos"), py::arg("max_allele_value") = -1)
         .def_static(
             "from_TreeSequence",
             [](py::object ts,

--- a/tests/test_VariantMatrix.py
+++ b/tests/test_VariantMatrix.py
@@ -18,9 +18,9 @@ class testVariantMatrix(unittest.TestCase):
         self.assertEqual(self.m.nsites, 2)
 
     def testModifyCppDataViaNumpy(self):
-        d = np.array(self.m, copy=False)
-        d[0][2] = 4
-        self.assertEqual(self.m.data[0][2], 4)
+        d = np.array(self.m.data, copy=False)
+        with self.assertRaises(ValueError):
+            d[0][2] = 4
 
     def testFilterSites(self):
         from collections import Counter
@@ -77,7 +77,10 @@ class testCreationFromNumpy(unittest.TestCase):
         d = np.array([0, 1, 1, 0, 0, 0, 0, 1], dtype=np.int8).reshape((2, 4))
         pos = np.array([0.1, 0.2])
         m = libsequence.VariantMatrix(d, pos)
-        ma = np.array(m)
+        self.assertTrue(m.data.flags.writeable is False)
+        # d is changed to non-writeable, too!
+        self.assertTrue(d.flags.writeable is False)
+        ma = np.array(m.data, copy=True)
         self.assertTrue(np.array_equal(np.sum(ma, axis=0), np.sum(d, axis=0)))
         self.assertTrue(np.array_equal(np.sum(ma, axis=1), np.sum(d, axis=1)))
 

--- a/tests/test_VariantMatrix.py
+++ b/tests/test_VariantMatrix.py
@@ -11,7 +11,8 @@ class testVariantMatrix(unittest.TestCase):
         self.m = libsequence.VariantMatrix(self.data, self.pos)
 
     def testConstruct(self):
-        self.assertEqual(self.m.data, self.data)
+        self.assertTrue(np.array_equal(self.m.data, np.array(
+            self.data).reshape(self.m.nsites, self.m.nsam)))
         self.assertTrue(np.array_equal(self.m.positions, self.pos))
         self.assertEqual(self.m.nsam, 4)
         self.assertEqual(self.m.nsites, 2)
@@ -19,7 +20,7 @@ class testVariantMatrix(unittest.TestCase):
     def testModifyCppDataViaNumpy(self):
         d = np.array(self.m, copy=False)
         d[0][2] = 4
-        self.assertEqual(self.m.data[2], 4)
+        self.assertEqual(self.m.data[0][2], 4)
 
     def testFilterSites(self):
         from collections import Counter

--- a/tests/test_VariantMatrix.py
+++ b/tests/test_VariantMatrix.py
@@ -109,6 +109,7 @@ class testCreationFromNumpy(unittest.TestCase):
     def testFilterSites(self):
         m = libsequence.VariantMatrix(self.d, self.pos)
         libsequence.filter_sites(m, is_singleton)
+        self.assertEqual(m.nsites, 1)
 
 
 class testDataFromMsprime(unittest.TestCase):

--- a/tests/test_VariantMatrix.py
+++ b/tests/test_VariantMatrix.py
@@ -41,7 +41,7 @@ class testVariantMatrix(unittest.TestCase):
         import pickle
         p = pickle.dumps(self.m, -1)
         up = pickle.loads(p)
-        self.assertEqual(up.data, self.m.data)
+        self.assertTrue(np.array_equal(up.data, self.m.data))
         self.assertTrue(np.array_equal(up.positions, self.m.positions))
         self.assertEqual(up.nsam, self.m.nsam)
         self.assertEqual(up.nsites, self.m.nsites)


### PR DESCRIPTION
Update to use the current libsequence API where VariantMatrix now uses a semi-generic "capsule" API for memory management.

This allows copy-free transfer from numpy arrays!!!!