### PR TITLE
Merging allele counts

### DIFF
--- a/libsequence/_tskit_tools.py
+++ b/libsequence/_tskit_tools.py
@@ -1,0 +1,32 @@
+import numpy as np
+from ._libsequence import VariantMatrix
+from ._libsequence import AlleleCountMatrix
+
+
+def _process_temp_containers(temp, pos, ac):
+    vm = VariantMatrix(np.array(temp), np.array(pos))
+    vmac = AlleleCountMatrix(vm)
+    if ac is None:
+        ac = vmac
+    else:
+        ac = ac._merge(vmac)
+    return ac
+
+
+def AlleleCountMatrix_from_tree_sequence(ts, chunksize=50):
+    ac = None
+    temp = []
+    pos = []
+    for v in ts.variants():
+        if len(temp) < chunksize:
+            temp.append(np.array(v.genotypes, copy=True, dtype=np.int8))
+            pos.append(v.position)
+        else:
+            ac = _process_temp_containers(temp, pos, ac)
+            temp = [np.array(v.genotypes, copy=True, dtype=np.int8)]
+            pos = [v.position]
+
+    if len(temp) > 0:
+        ac = _process_temp_containers(temp, pos, ac)
+
+    return ac

--- a/libsequence/src/variant_matrix.cc
+++ b/libsequence/src/variant_matrix.cc
@@ -152,15 +152,15 @@ class NumpyGenotypeCapsule : public Sequence::GenotypeCapsule
     }
 
     std::int8_t &
-    operator()(std::size_t site, std::size_t sample)  final
+    operator()(std::size_t site, std::size_t sample) final
     {
-        return buffer.mutable_data()[nsam()*site + sample];
+        return buffer.mutable_data()[nsam() * site + sample];
     }
 
     const std::int8_t &
     operator()(std::size_t site, std::size_t sample) const final
     {
-        return buffer.data()[nsam()*site + sample];
+        return buffer.data()[nsam() * site + sample];
     }
 
     bool
@@ -380,7 +380,19 @@ init_VariantMatrix(py::module &m)
                         sizeof(value_type) * c.ncol, sizeof(value_type)
                         /* Strides (in bytes) for each index */
                     });
-            });
+            })
+        .def("_merge", [](const Sequence::AlleleCountMatrix &self,
+                          const Sequence::AlleleCountMatrix &acm) {
+            if (self.nsam != acm.nsam || self.ncol != acm.ncol)
+                {
+                    throw std::invalid_argument("dimension mismatch");
+                }
+            auto counts = self.counts;
+            counts.insert(end(counts), begin(acm.counts),
+                          end(acm.counts));
+            return Sequence::AlleleCountMatrix(std::move(counts), self.ncol,
+                                               self.nrow + acm.nrow, self.nsam);
+        });
 
     py::class_<Sequence::VariantMatrix>(m, "VariantMatrix",
                                         //py::buffer_protocol(),

--- a/tests/test_AlleleCountMatrix.py
+++ b/tests/test_AlleleCountMatrix.py
@@ -7,9 +7,9 @@ import libsequence
 class testAlleleCountMatrix(unittest.TestCase):
     @classmethod
     def setUp(self):
-        ts = msprime.simulate(10, mutation_rate=10, random_seed=42)
+        self.ts = msprime.simulate(10, mutation_rate=10, random_seed=42)
         self.vm = libsequence.VariantMatrix.from_TreeSequence(
-            ts)
+            self.ts)
         self.ac = libsequence.AlleleCountMatrix(self.vm)
 
     def testSubset(self):
@@ -40,6 +40,10 @@ class testAlleleCountMatrix(unittest.TestCase):
             rr = merged.row(i+self.ac.nrow)
             for j, k in zip(r, rr):
                 self.assertEqual(j, k)
+
+    def testFromTreeSequence(self):
+        ac = libsequence.AlleleCountMatrix.from_tskit(self.ts)
+        self.assertTrue(np.array_equal(np.array(ac), np.array(self.ac)))
 
 
 if __name__ == "__main__":

--- a/tests/test_AlleleCountMatrix.py
+++ b/tests/test_AlleleCountMatrix.py
@@ -32,6 +32,15 @@ class testAlleleCountMatrix(unittest.TestCase):
             row_j = acw.row(j)
             self.assertTrue(all(k == l for k, l in zip(row_i, row_j)) is True)
 
+    def testMerge(self):
+        merged = self.ac._merge(self.ac)
+        self.assertEqual(merged.nrow, 2*self.ac.nrow)
+        for i in range(self.ac.nrow):
+            r = self.ac.row(i)
+            rr = merged.row(i+self.ac.nrow)
+            for j, k in zip(r, rr):
+                self.assertEqual(j, k)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allow direct construction of AlleleCountMatrix from a tskit.TreeSequence.  This bypasses the generation of the 0/1 genotype matrix, which can save a lot of RAM.